### PR TITLE
Fix Tested Up To Value is Out of Date, Invalid, or Missing

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@ Contributors: bananacrystal
 Donate link: https://www.bananacrystal.com/
 Tags: payments, bananacrystal, woocommerce payment gateway
 Requires at least: 5.0
-Tested up to: 6.0.3
+Tested up to: 6.1.1
 Stable tag: 1.0.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
update tested upto value in readme file to latest wordpress version