### PR TITLE
Cleanup sender_ref, ref parameter naming to subscription_user_id and order_id

### DIFF
--- a/cron.php
+++ b/cron.php
@@ -14,7 +14,7 @@ function bc_renew_subscription() {
                 'sender' => $subscription->buyer_user_name,
                 'amount' => $subscription->subscription_amount,
                 'note' => $subscription->subscription_title,
-                'sender_ref' => $subscription->user_id,
+                'subscription_user_id' => $subscription->user_id,
                 'subscription_id' => $subscription->subscription_plan_id,
                 'subscriber_username' => $subscription->buyer_user_name,
                 'store_username' => $store_username

--- a/includes/class-banana-crystal-subscription.php
+++ b/includes/class-banana-crystal-subscription.php
@@ -43,7 +43,7 @@ class Banana_Crystal_Subscription {
 				$banana_crystal_settings = WC()->payment_gateways->payment_gateways()['wo_banana_crystal']->settings;
 
 				//redirect urser to store banana crystal payment page
-				$params = '?amount='.$result->subscription_plan_amount.'&note='.$result->subscription_plan_title.'&ref='.$user->ID.'&sd=&subscription_id='.$result->subscription_plan_id.'&subscriber_username='.$user->user_login;
+				$params = '?amount='.$result->subscription_plan_amount.'&note='.$result->subscription_plan_title.'&subscription_user_id='.$user->ID.'&sd=&subscription_id='.$result->subscription_plan_id.'&subscriber_username='.$user->user_login;
 				$store_user_name = $banana_crystal_settings['store_username'];
 				$redirect_url = 'https://app.bananacrystal.com/pay_subscriptions/'.$store_user_name.$params;
 				wp_redirect( $redirect_url );

--- a/includes/class-banana-crystal-woocommerce.php
+++ b/includes/class-banana-crystal-woocommerce.php
@@ -237,7 +237,7 @@ class Woocommerce_Banana_Crystal extends WC_Payment_Gateway {
                 
         
         //redirect urser to store banana crystal payment page
-        $params = '?amount='.$order->order_total.'&note='.$notes.'&ref='.$order_id.'&sd='. base64_encode($order_key);
+        $params = '?amount='.$order->order_total.'&note='.$notes.'&order_id='.$order_id.'&sd='. base64_encode($order_key);
         $store_user_name = $this->get_option( 'store_username' );
         $redirect_url = 'https://app.bananacrystal.com/payme/'.$store_user_name.$params;
     
@@ -308,7 +308,7 @@ class Woocommerce_Banana_Crystal extends WC_Payment_Gateway {
 			if ($result) {
 				$user = wp_get_current_user();
 				//redirect urser to store banana crystal payment page
-				$params = '?amount='.$result->subscription_plan_amount.'&note='.$result->subscription_plan_title.'&ref='.$user->ID.'&sd=&subscription_id='.$result->subscription_plan_id.'&subscriber_username='.$user->user_login;
+				$params = '?amount='.$result->subscription_plan_amount.'&note='.$result->subscription_plan_title.'&subscription_user_id='.$user->ID.'&sd=&subscription_id='.$result->subscription_plan_id.'&subscriber_username='.$user->user_login;
 				$store_user_name = $this->get_option( 'store_username' );
 				$redirect_url = 'https://app.bananacrystal.com/pay_subscriptions/'.$store_user_name.$params;
 				wp_redirect( $redirect_url );


### PR DESCRIPTION
## What

* Update ref and sender_ref parameters with order_id and subscription_plan_id, respectively

## Why

* To cleanup naming and handle the redirect when a customer makes direct payments to the store w/o checkout (not via woocommerce funnel) and store owner has a woocommerce store.