### PR TITLE
Fix Incorrect Stable Tag

### DIFF
--- a/woocommerce-gateway-banana-crystal.php
+++ b/woocommerce-gateway-banana-crystal.php
@@ -15,7 +15,7 @@
  * @wordpress-plugin
  * Plugin Name:       BananaCrystal Payment Gateway
  * Description:       Fast secure, low-cost, borderless, local and international payments in USD powered by blockchain/crypto payment rails. Send and receive secure peer to peer payments to anyone instantly at no cost to you.
- * Version:           1.2.0
+ * Version:           1.2.1
  * Author:            Banana Crystal
  * Author URI:        https://www.bananacrystal.com/
  * License:           GPL-2.0+


### PR DESCRIPTION
## What

Fix In your readme, your 'Stable Tag' does not match the Plugin Version as indicated in your main plugin file.

## Why


## How to test


## References/Links
