### PR TITLE
Add support for return url to allow customer to return back to merchant

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -3,8 +3,8 @@ Contributors: bananacrystal
 Donate link: https://www.bananacrystal.com/
 Tags: payments, bananacrystal, woocommerce, payment gateway
 Requires at least: 5.0
-Tested up to: 6.1.1
-Stable tag: 1.2.4
+Tested up to: 6.3
+Stable tag: 1.2.5
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -71,7 +71,7 @@ First, setup your BananaCrystal merchant/business account for your Woocommerce s
 
 Follow the [Wordpress guidelines on how to install a plugin](https://wordpress.org/support/article/managing-plugins/#installing-plugins-1)
 
-Then navigate to the plugin's admin settings and enter your BananaCrystal store username, redirect url, and payment notification webhook url.
+Then navigate to the plugin's admin settings and enter your BananaCrystal store username, redirect url, order pay url, and payment notification webhook url.
 
 For a detailed guide, see [How to Install the BananaCrystal Payment Gateway Plugin](https://support.bananacrystal.com/hc/en-us/articles/10231530050327)
 
@@ -80,12 +80,11 @@ For a detailed guide, see [How to Install the BananaCrystal Payment Gateway Plug
 
 Login to your BananaCrystal account and go to Store > Settings.
 
-= Where do I configure my redirect url or payment notification webhook?
+= Where do I configure my redirect url or payment notification webhook or order pay url?
 
 Login to your BananaCrystal account and go to Store > Integrations.
 
 Then, add or update a Woocommerce Integration
-
 
 = Where do I get my subscription key or redirect url for thank you page?
 

--- a/woocommerce-gateway-banana-crystal.php
+++ b/woocommerce-gateway-banana-crystal.php
@@ -15,7 +15,7 @@
  * @wordpress-plugin
  * Plugin Name:       BananaCrystal Payment Gateway
  * Description:       Fast secure, low-cost, borderless, local and international payments in USD powered by blockchain/crypto payment rails. Send and receive secure peer to peer payments to anyone instantly at no cost to you.
- * Version:           1.2.4
+ * Version:           1.2.5
  * Author:            Banana Crystal
  * Author URI:        https://www.bananacrystal.com/
  * License:           GPL-2.0+
@@ -34,7 +34,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'WOOCOMMERCE_GATEWAY_BANANA_CRYSTAL_VERSION', '1.2.4' );
+define( 'WOOCOMMERCE_GATEWAY_BANANA_CRYSTAL_VERSION', '1.2.5' );
 
 /**
  * The code that runs during plugin activation.


### PR DESCRIPTION
## What

- Add an order pay page to redirect customers back from BananaCrystal payment to the merchant's Woocommerce store
- Change the default order status from on-hold to pending payment to allow orders to be paid at a later time (e.g. when customer clicks on the redirect link back to the merchant or needs to fund their BananaCrystal account).

## Why

- To allow customers to return back to merchant
- To allow customers to continue where they left off and pay for an order that is pending payment

## How to test

1. Go the Wordpress Admin plugin configuration settings
2. Then copy the return url
3. Go to BananaCrystal Woocommerce integration settings
4. Paste the order pay url (return url) in the return url field and save
5. Check out as a customer. Notice that at the bottom of the page page there is the return url link

## References/Links
