### PR TITLE
[BC-606] Test with WP 6.6 and Update 1.2.6

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://www.bananacrystal.com/
 Tags: payments, bananacrystal, woocommerce, payment gateway
 Requires at least: 5.0
 Tested up to: 6.3
-Stable tag: 1.2.5
+Stable tag: 1.2.6
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://www.bananacrystal.com/
 Tags: payments, bananacrystal, woocommerce, payment gateway
 Requires at least: 5.0
 Tested up to: 6.3
-Stable tag: 1.2.6
+Stable tag: 1.2.5
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@ Contributors: bananacrystal
 Donate link: https://www.bananacrystal.com/
 Tags: payments, bananacrystal, woocommerce, payment gateway
 Requires at least: 5.0
-Tested up to: 6.3
+Tested up to: 6.6.1
 Stable tag: 1.2.5
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://www.bananacrystal.com/
 Tags: payments, bananacrystal, woocommerce, payment gateway
 Requires at least: 5.0
 Tested up to: 6.6.1
-Stable tag: 1.2.5
+Stable tag: 1.2.6
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/woocommerce-gateway-banana-crystal.php
+++ b/woocommerce-gateway-banana-crystal.php
@@ -15,7 +15,7 @@
  * @wordpress-plugin
  * Plugin Name:       BananaCrystal Payment Gateway
  * Description:       Fast secure, low-cost, borderless, local and international payments in USD powered by blockchain/crypto payment rails. Send and receive secure peer to peer payments to anyone instantly at no cost to you.
- * Version:           1.2.6
+ * Version:           1.2.5
  * Author:            Banana Crystal
  * Author URI:        https://www.bananacrystal.com/
  * License:           GPL-2.0+
@@ -34,7 +34,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'WOOCOMMERCE_GATEWAY_BANANA_CRYSTAL_VERSION', '1.2.6' );
+define( 'WOOCOMMERCE_GATEWAY_BANANA_CRYSTAL_VERSION', '1.2.5' );
 
 /**
  * The code that runs during plugin activation.

--- a/woocommerce-gateway-banana-crystal.php
+++ b/woocommerce-gateway-banana-crystal.php
@@ -15,7 +15,7 @@
  * @wordpress-plugin
  * Plugin Name:       BananaCrystal Payment Gateway
  * Description:       Fast secure, low-cost, borderless, local and international payments in USD powered by blockchain/crypto payment rails. Send and receive secure peer to peer payments to anyone instantly at no cost to you.
- * Version:           1.2.5
+ * Version:           1.2.8
  * Author:            Banana Crystal
  * Author URI:        https://www.bananacrystal.com/
  * License:           GPL-2.0+
@@ -34,7 +34,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'WOOCOMMERCE_GATEWAY_BANANA_CRYSTAL_VERSION', '1.2.5' );
+define( 'WOOCOMMERCE_GATEWAY_BANANA_CRYSTAL_VERSION', '1.2.6' );
 
 /**
  * The code that runs during plugin activation.

--- a/woocommerce-gateway-banana-crystal.php
+++ b/woocommerce-gateway-banana-crystal.php
@@ -15,7 +15,7 @@
  * @wordpress-plugin
  * Plugin Name:       BananaCrystal Payment Gateway
  * Description:       Fast secure, low-cost, borderless, local and international payments in USD powered by blockchain/crypto payment rails. Send and receive secure peer to peer payments to anyone instantly at no cost to you.
- * Version:           1.2.5
+ * Version:           1.2.6
  * Author:            Banana Crystal
  * Author URI:        https://www.bananacrystal.com/
  * License:           GPL-2.0+
@@ -34,7 +34,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'WOOCOMMERCE_GATEWAY_BANANA_CRYSTAL_VERSION', '1.2.5' );
+define( 'WOOCOMMERCE_GATEWAY_BANANA_CRYSTAL_VERSION', '1.2.6' );
 
 /**
  * The code that runs during plugin activation.

--- a/woocommerce-gateway-banana-crystal.php
+++ b/woocommerce-gateway-banana-crystal.php
@@ -15,7 +15,7 @@
  * @wordpress-plugin
  * Plugin Name:       BananaCrystal Payment Gateway
  * Description:       Fast secure, low-cost, borderless, local and international payments in USD powered by blockchain/crypto payment rails. Send and receive secure peer to peer payments to anyone instantly at no cost to you.
- * Version:           1.2.8
+ * Version:           1.2.6
  * Author:            Banana Crystal
  * Author URI:        https://www.bananacrystal.com/
  * License:           GPL-2.0+


### PR DESCRIPTION
## What
Release version 1.2.6

## Why
The plugin is no longer supported for newer version of Wordpress so there is need to update so that it is compatible up to 6.6.x

## How to test


## References/Links
