### PR TITLE
[BC-725] Feat: Include Store Currency with Checkout Param

### DIFF
--- a/admin/views/add_subscription_plan_view.php
+++ b/admin/views/add_subscription_plan_view.php
@@ -38,7 +38,7 @@
 							<tr valign="top">
                                 <th scope="row">Recurring Amount:</th>
                                 <td>
-                                    <input type="text" name="plan_recurring_amount" min="10" required
+                                    <input type="text" name="plan_recurring_amount" min="0" required
                                            value="<?php echo $plan_row ? number_format($plan_row->subscription_plan_amount, 2) : ''; ?>"/>
                                 </td>
                             </tr>

--- a/admin/views/add_subscription_plan_view.php
+++ b/admin/views/add_subscription_plan_view.php
@@ -38,7 +38,7 @@
 							<tr valign="top">
                                 <th scope="row">Recurring Amount:</th>
                                 <td>
-                                    <input type="text" name="plan_recurring_amount" min="0" required
+                                    <input type="text" name="plan_recurring_amount" min="10" required
                                            value="<?php echo $plan_row ? number_format($plan_row->subscription_plan_amount, 2) : ''; ?>"/>
                                 </td>
                             </tr>

--- a/admin/views/current_subscription_front.php
+++ b/admin/views/current_subscription_front.php
@@ -64,7 +64,9 @@
                             <div class="pack_price">
 
                                 <span class="dps-amount">
-                                    <span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">$</span><?php echo number_format($plan->subscription_amount, 2); ?></bdi></span>                                </span>
+                                    <span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">
+                                    <?php echo get_woocommerce_currency(); ?>  
+                                    </span><?php echo number_format($plan->subscription_amount, 2); ?></bdi></span>                                </span> 
                                     <span class="dps-rec-period">
                                         <span class="sep">/</span><?php echo esc_html(banana_crystal_format_occurrence($plan->subscription_occurrence)); ?>                                   
                                     </span>

--- a/admin/views/subscription_plans_front.php
+++ b/admin/views/subscription_plans_front.php
@@ -64,7 +64,9 @@
                             <div class="pack_price">
 
                                 <span class="dps-amount">
-                                    <span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">$</span><?php echo number_format($plan->subscription_plan_amount, 2); ?></bdi></span>                                </span>
+                                    <span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">
+                                    <?php echo get_woocommerce_currency(); ?>  
+                                    </span><?php echo number_format($plan->subscription_plan_amount, 2); ?></bdi></span>                                </span>
                                     <span class="dps-rec-period">
                                         <span class="sep">/</span> <?php echo esc_html(banana_crystal_format_occurrence($plan->subscription_plan_occurrence)); ?>                                   
                                     </span>

--- a/includes/class-banana-crystal-woocommerce.php
+++ b/includes/class-banana-crystal-woocommerce.php
@@ -249,9 +249,11 @@ class Woocommerce_Banana_Crystal extends WC_Payment_Gateway {
            $notes .= $product_name.' x '.$quantity.'\n';
         }
                 
-        
+        // Get store's currency
+    	$currency = get_woocommerce_currency();
+
         //redirect user to store banana crystal payment page
-        $params = '?amount='.$order->order_total.'&note='.$notes.'&order_id='.$order_id.'&sd='. base64_encode($order_key);
+        $params = '?amount='.$order->order_total.'&note='.$notes.'&order_id='.$order_id.'&sd='.'&currency='.$currency.'&sd='. base64_encode($order_key);
         $store_user_name = $this->get_option( 'store_username' );
         $redirect_url = 'https://app.bananacrystal.com/payme/'.$store_user_name.$params;
     
@@ -321,8 +323,12 @@ class Woocommerce_Banana_Crystal extends WC_Payment_Gateway {
 			$result = $wpdb->get_row("SELECT * FROM $table_name");
 			if ($result) {
 				$user = wp_get_current_user();
+
+				// get store currency
+				$currency = get_woocommerce_currency();
+
 				//redirect user to store banana crystal payment page
-				$params = '?amount='.$result->subscription_plan_amount.'&note='.$result->subscription_plan_title.'&subscriber_user_id='.base64_encode($user->ID).'&sd=&subscription_id='.$result->subscription_plan_id.'&subscriber_username='.base64_encode($user->user_login);
+				$params = '?amount='.$result->subscription_plan_amount.'&note='.$result->subscription_plan_title.'&currency='.$currency.'&subscriber_user_id='.base64_encode($user->ID).'&sd=&subscription_id='.$result->subscription_plan_id.'&subscriber_username='.base64_encode($user->user_login);
 				$store_user_name = $this->get_option( 'store_username' );
 				$redirect_url = 'https://app.bananacrystal.com/pay_subscriptions/'.$store_user_name.$params;
 				wp_redirect( $redirect_url );

--- a/includes/class-banana-crystal-woocommerce.php
+++ b/includes/class-banana-crystal-woocommerce.php
@@ -253,7 +253,7 @@ class Woocommerce_Banana_Crystal extends WC_Payment_Gateway {
     	$currency = get_woocommerce_currency();
 
         //redirect user to store banana crystal payment page
-        $params = '?amount='.$order->order_total.'&note='.$notes.'&order_id='.$order_id.'&sd='.'&currency='.$currency.'&sd='. base64_encode($order_key);
+        $params = '?amount='.$order->order_total.'&note='.$notes.'&order_id='.$order_id.'&currency='.$currency.'&sd='. base64_encode($order_key);
         $store_user_name = $this->get_option( 'store_username' );
         $redirect_url = 'https://app.bananacrystal.com/payme/'.$store_user_name.$params;
     


### PR DESCRIPTION
## What
Include the store's currency in the params with the amount in the checkout

## Why
This will allow store owners to receive payment in their store local currency and be credited in USD into their BC account

## How to test
Checkout from a store and confirm the currency-param is included in the URL 

Video showing the store checkout URL has currency param: https://www.loom.com/share/6375170b6a5d4224a4ae28950a8a6540?sid=f2a94beb-4ed2-4db8-b1d2-4a4a4df9c2d1

`/payme/ellington?amount=8000.00&note=Power%20your%20dreams%20book%20x%201\n&order_id=5064&sd=UHRSRDhDRFhWUkc3Rg==&currency=NGN`

## References/Links
https://trello.com/c/z5FD4dk2
